### PR TITLE
Allow Bromite bottom toolbar patches to be merged into Vanadium under the MIT license?

### DIFF
--- a/.github/workflows/check-git-apply.yaml
+++ b/.github/workflows/check-git-apply.yaml
@@ -1,3 +1,4 @@
+#dummy commit
 name: Check git apply
 #permissions:
 #  actions: none


### PR DESCRIPTION
Hello, it would be nice to have the option to move the navigation bar to the bottom in Vanadium as well.

However, Vanadium uses the same license (MIT license) as upstream Chromium, while Bromite is licensed under the GPLv3, so merging your Bromite patch would require it to be available under the MIT license.

Would you be willing to license your patches for this features under the MIT license as well and submit them to the Vanadium project?
